### PR TITLE
Automatische Änderung in Edit Dialogen

### DIFF
--- a/BusinessLogic/Commands/Element/EditLearningElement.cs
+++ b/BusinessLogic/Commands/Element/EditLearningElement.cs
@@ -52,7 +52,7 @@ public class EditLearningElement : IEditLearningElement
             LearningElement.Goals, LearningElement.Difficulty, LearningElement.ElementModel, LearningElement.Workload,
             LearningElement.Points, LearningElement.LearningContent.Name);
 
-        if (AnyChange()) LearningElement.UnsavedChanges = true;
+        if (AnyChanges()) LearningElement.UnsavedChanges = true;
         LearningElement.Name = ElementName;
         LearningElement.Parent = ParentSpace;
         LearningElement.Description = Description;
@@ -93,7 +93,7 @@ public class EditLearningElement : IEditLearningElement
         Execute();
     }
 
-    private bool AnyChange() =>
+    public bool AnyChanges() =>
         LearningElement.Name != ElementName ||
         LearningElement.Parent != ParentSpace ||
         LearningElement.Description != Description ||

--- a/BusinessLogic/Commands/Element/EditLearningElement.cs
+++ b/BusinessLogic/Commands/Element/EditLearningElement.cs
@@ -102,5 +102,5 @@ public class EditLearningElement : IEditLearningElement
         LearningElement.ElementModel != ElementModel ||
         LearningElement.Workload != Workload ||
         LearningElement.Points != Points ||
-        LearningElement.LearningContent != LearningContent;
+        !LearningElement.LearningContent.Equals(LearningContent);
 }

--- a/BusinessLogic/Commands/Element/IEditLearningElement.cs
+++ b/BusinessLogic/Commands/Element/IEditLearningElement.cs
@@ -2,4 +2,5 @@ namespace BusinessLogic.Commands.Element;
 
 public interface IEditLearningElement : IUndoCommand
 {
+    bool AnyChanges();
 }

--- a/BusinessLogic/Commands/Space/EditLearningSpace.cs
+++ b/BusinessLogic/Commands/Space/EditLearningSpace.cs
@@ -81,7 +81,7 @@ public class EditLearningSpace : IEditLearningSpace
         Execute();
     }
 
-    private bool AnyChanges() =>
+    public bool AnyChanges() =>
         LearningSpace.Name != SpaceName ||
         LearningSpace.Description != Description ||
         LearningSpace.Goals != Goals ||

--- a/BusinessLogic/Commands/Space/IEditLearningSpace.cs
+++ b/BusinessLogic/Commands/Space/IEditLearningSpace.cs
@@ -2,4 +2,5 @@ namespace BusinessLogic.Commands.Space;
 
 public interface IEditLearningSpace : IUndoCommand
 {
+    bool AnyChanges();
 }

--- a/BusinessLogic/Commands/World/EditLearningWorld.cs
+++ b/BusinessLogic/Commands/World/EditLearningWorld.cs
@@ -83,7 +83,7 @@ public class EditLearningWorld : IEditLearningWorld
         Execute();
     }
 
-    private bool AnyChanges() =>
+    public bool AnyChanges() =>
         LearningWorld.Name != WorldName ||
         LearningWorld.Shortname != Shortname ||
         LearningWorld.Authors != Authors ||

--- a/BusinessLogic/Commands/World/IEditLearningWorld.cs
+++ b/BusinessLogic/Commands/World/IEditLearningWorld.cs
@@ -2,4 +2,5 @@ namespace BusinessLogic.Commands.World;
 
 public interface IEditLearningWorld : IUndoCommand
 {
+    bool AnyChanges();
 }

--- a/BusinessLogic/Entities/LearningContent/FileContent.cs
+++ b/BusinessLogic/Entities/LearningContent/FileContent.cs
@@ -25,4 +25,33 @@ public class FileContent : IFileContent
     public string Name { get; set; }
     public string Type { get; set; }
     public string Filepath { get; set; }
+
+    public bool Equals(ILearningContent? other)
+    {
+        if (other is not IFileContent fileContent) return false;
+        return Name == fileContent.Name && Type == fileContent.Type && Filepath == fileContent.Filepath;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != typeof(FileContent)) return false;
+        return Equals((FileContent)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Name, Type, Filepath);
+    }
+
+    public static bool operator ==(FileContent? left, FileContent? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(FileContent? left, FileContent? right)
+    {
+        return !Equals(left, right);
+    }
 }

--- a/BusinessLogic/Entities/LearningContent/ILearningContent.cs
+++ b/BusinessLogic/Entities/LearningContent/ILearningContent.cs
@@ -1,6 +1,6 @@
 namespace BusinessLogic.Entities.LearningContent;
 
-public interface ILearningContent
+public interface ILearningContent : IEquatable<ILearningContent>
 {
     string Name { get; set; }
 }

--- a/BusinessLogic/Entities/LearningContent/LinkContent.cs
+++ b/BusinessLogic/Entities/LearningContent/LinkContent.cs
@@ -22,4 +22,33 @@ public class LinkContent : ILinkContent
 
     public string Name { get; set; }
     public string Link { get; set; }
+
+    public bool Equals(ILearningContent? other)
+    {
+        if(other is not LinkContent linkContent) return false;
+        return Name == linkContent.Name && Link == linkContent.Link;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+        return Equals((LinkContent)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Name, Link);
+    }
+
+    public static bool operator ==(LinkContent? left, LinkContent? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(LinkContent? left, LinkContent? right)
+    {
+        return !Equals(left, right);
+    }
 }

--- a/IntegrationTest/Forms/Element/EditElementFormIt.cs
+++ b/IntegrationTest/Forms/Element/EditElementFormIt.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Bunit;
 using BusinessLogic.Entities;
@@ -7,6 +9,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
 using NSubstitute;
+using NSubstitute.ClearExtensions;
 using NUnit.Framework;
 using Presentation.Components.Forms;
 using Presentation.Components.Forms.Buttons;
@@ -132,7 +135,7 @@ public class EditElementFormIt : MudFormTestFixture<EditElementForm, LearningEle
 
         systemUnderTest.FindComponent<SubmitThenRemapButton>().Find("button").Click();
 
-        Assert.That(() => WorldPresenter.Received(1).EditLearningElement(vm.Parent, vm, Expected, Expected, Expected,
+        Assert.That(() => WorldPresenter.Received(2).EditLearningElement(vm.Parent, vm, Expected, Expected, Expected,
                 LearningElementDifficultyEnum.Hard, ElementModel.l_random, 123, 123, LearningContentViewModels[0]),
             Throws.Nothing);
         Mapper.Received(1).Map(vm, FormDataContainer.FormModel);
@@ -219,7 +222,7 @@ public class EditElementFormIt : MudFormTestFixture<EditElementForm, LearningEle
     }
 
     private IRenderedFragment GetFormWithPopoverProvider(ILearningElementViewModel? vm = null,
-        EventCallback? onNewClicked = null, Action? masterLayoutStateHasChanged = null)
+        EventCallback? onNewClicked = null, Action? masterLayoutStateHasChanged = null, int debounceInterval = 0)
     {
         vm ??= ViewModelProvider.GetLearningElement();
         onNewClicked ??= EventCallback.Empty;
@@ -230,7 +233,7 @@ public class EditElementFormIt : MudFormTestFixture<EditElementForm, LearningEle
             builder.CloseComponent();
             builder.OpenComponent<EditElementForm>(1);
             builder.AddAttribute(2, nameof(EditElementForm.ElementToEdit), vm);
-            builder.AddAttribute(3, nameof(CreateElementForm.DebounceInterval), 0);
+            builder.AddAttribute(3, nameof(EditElementForm.DebounceInterval), debounceInterval);
             builder.AddAttribute(4, nameof(EditElementForm.OnNewButtonClicked), onNewClicked.Value);
             builder.CloseComponent();
         };

--- a/IntegrationTest/Forms/Space/EditSpaceFormIt.cs
+++ b/IntegrationTest/Forms/Space/EditSpaceFormIt.cs
@@ -181,7 +181,7 @@ public class EditSpaceFormIt : MudFormTestFixture<EditSpaceForm, LearningSpaceFo
 
         systemUnderTest.FindComponent<SubmitThenRemapButton>().Find("button").Click();
 
-        SpacePresenter.Received(1).EditLearningSpace(Expected, Expected, Expected, 123, Theme.Campus);
+        SpacePresenter.Received(2).EditLearningSpace(Expected, Expected, Expected, 123, Theme.Campus);
         Mapper.Received(1).Map(vm, FormDataContainer.FormModel);
     }
 

--- a/IntegrationTest/Forms/World/EditWorldFormIt.cs
+++ b/IntegrationTest/Forms/World/EditWorldFormIt.cs
@@ -171,7 +171,7 @@ public class EditWorldFormIt : MudFormTestFixture<EditWorldForm, LearningWorldFo
 
         systemUnderTest.FindComponent<SubmitThenRemapButton>().Find("button").Click();
 
-        WorldPresenter.Received(1).EditLearningWorld(Expected, Expected, Expected, Expected,
+        WorldPresenter.Received(2).EditLearningWorld(Expected, Expected, Expected, Expected,
             Expected, Expected, Expected);
         Mapper.Received(1).Map(worldToMap, FormDataContainer.FormModel);
     }

--- a/Presentation/Components/Forms/BaseForm.razor
+++ b/Presentation/Components/Forms/BaseForm.razor
@@ -1,6 +1,7 @@
 @typeparam TForm where TForm : new()
 @typeparam TEntity
 @using System.Diagnostics.CodeAnalysis
+@using MudBlazor.Utilities
 @implements IBaseForm
 
 <MudCardActions Class="flex flex-col justify-center items-center">
@@ -11,7 +12,7 @@
     </MudButtonGroup>
 </MudCardActions>
 
-<MudForm Model="@FormDataContainer.FormModel" @ref="@_form" Validation="@ValidateModel">
+<MudForm Model="@FormDataContainer.FormModel" @ref="@_form" Validation="@ValidateModel" FieldChanged="@FieldChanged">
     <MudCardContent>
         @Fields
         @if (SubmitErrorMessage != null)
@@ -42,6 +43,9 @@
 
     [Parameter, EditorRequired]
     public EventCallback<TForm> OnValidSubmit { get; set; }
+    
+    [Parameter]
+    public EventCallback<TForm> OnValidFieldChange { get; set; }
 
     [Parameter, EditorRequired, AllowNull] //allow null since not providing the parameter produces a warning - n.stich
     public string SnackbarMessage { get; set; }
@@ -98,6 +102,16 @@
                 SubmitErrorMessage = $"An error has occured trying to submit the form: {e.Message}";
             }
         }
+    }
+
+
+    private async Task FieldChanged(FormFieldChangedEventArgs e)
+    {
+        //quit early if nobody is listening anyway
+        if(!OnValidFieldChange.HasDelegate) return;
+        if (_form == null) throw new ApplicationException("_form is null");
+        await _form.Validate();
+        if(_form.IsValid) await OnValidFieldChange.InvokeAsync(FormDataContainer.FormModel);
     }
 
 }

--- a/Presentation/Components/Forms/Element/EditElementForm.razor
+++ b/Presentation/Components/Forms/Element/EditElementForm.razor
@@ -17,7 +17,8 @@
 <MudDivider DividerType="DividerType.Middle" Class="mt-4 mb-2"></MudDivider>
 <MudText Class="text-adlergrey-200 w-4/4 px-4 text-xs">@Localizer["EditElementForm.Text"]</MudText>
 <BaseForm TForm="LearningElementFormModel" TEntity="LearningElement"
-          OnValidSubmit="OnValidSubmit" SnackbarMessage=@Localizer["EditElementForm.SnackbarMessage"] FormDataContainer="FormDataContainer">
+          OnValidSubmit="OnValidSubmit" OnValidFieldChange="OnValidFieldChange"
+          SnackbarMessage=@Localizer["EditElementForm.SnackbarMessage"] FormDataContainer="FormDataContainer">
     <HeaderButtons>
         <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="btn-standard"
                    OnClick="async () => await OnNewButtonClicked.InvokeAsync()">
@@ -211,6 +212,8 @@
             model.Goals, model.Difficulty, model.ElementModel, model.Workload, model.Points, model.LearningContent!);
         TriggerMasterLayoutStateHasChanged?.Invoke();
     }
+
+    private void OnValidFieldChange(LearningElementFormModel model) => OnValidSubmit(model);
 
     private async Task MapIntoContainer()
     {

--- a/Presentation/Components/Forms/Space/EditSpaceForm.razor
+++ b/Presentation/Components/Forms/Space/EditSpaceForm.razor
@@ -15,7 +15,8 @@
 <MudDivider DividerType="DividerType.Middle" Class="mt-4 mb-2"></MudDivider>
 <MudText Class="text-adlergrey-200 w-4/4 px-4 text-xs">@Localizer["EditSpaceForm.Text"]</MudText>
 <BaseForm TForm="LearningSpaceFormModel" TEntity="LearningSpace"
-          OnValidSubmit="OnValidSubmit" SnackbarMessage=@Localizer["EditSpaceForm.SnackbarMessage"]
+          OnValidSubmit="OnValidSubmit" OnValidFieldChange="OnValidFieldChange"
+          SnackbarMessage=@Localizer["EditSpaceForm.SnackbarMessage"]
           FormDataContainer="FormDataContainer">
     <HeaderButtons>
         <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="btn-standard"
@@ -139,6 +140,8 @@
         LearningSpacePresenter.EditLearningSpace(model.Name, model.Description,
             model.Goals, (int) model.RequiredPoints!, model.Theme);
     }
+
+    private void OnValidFieldChange(LearningSpaceFormModel model) => OnValidSubmit(model);
 
     private async Task MapIntoContainer()
     {

--- a/Presentation/Components/Forms/World/EditWorldForm.razor
+++ b/Presentation/Components/Forms/World/EditWorldForm.razor
@@ -13,7 +13,7 @@
 </header>
 <MudDivider DividerType="DividerType.Middle" Class="mt-4 mb-2"></MudDivider>
 <MudText Class="text-adlergrey-200 w-4/4 px-4 text-xs">@Localizer["EditWorldForm.Text"]</MudText>
-<BaseForm TForm="LearningWorldFormModel" TEntity="LearningWorld" OnValidSubmit="OnValidSubmit"
+<BaseForm TForm="LearningWorldFormModel" TEntity="LearningWorld" OnValidSubmit="OnValidSubmit" OnValidFieldChange="OnValidFieldChange"
           SnackbarMessage=@Localizer["EditWorldForm.SnackbarMessage"] FormDataContainer="FormDataContainer">
     <Fields>
         <Collapsable Title=@Localizer["EditWorldForm.Fields.Collapsable.General.Title"]
@@ -85,7 +85,6 @@
     [Inject, AllowNull] //can never be null, DI will throw exception on unresolved types - n.stich
     private IStringLocalizer<EditWorldForm> Localizer { get; set; }
 
-
     [Parameter, EditorRequired, AllowNull] //allow null since not providing the parameter produces a warning - n.stich
     public ILearningWorldViewModel WorldToEdit { get; set; }
 
@@ -104,6 +103,8 @@
     {
         LearningWorldPresenter.EditLearningWorld(model.Name, model.Shortname, model.Authors, model.Language, model.Description, model.Goals, model.EvaluationLink);
     }
+
+    private void OnValidFieldChange(LearningWorldFormModel model) => OnValidSubmit(model);
 
     private async Task MapIntoContainer()
     {

--- a/Presentation/PresentationLogic/API/PresentationLogic.cs
+++ b/Presentation/PresentationLogic/API/PresentationLogic.cs
@@ -164,6 +164,8 @@ public class PresentationLogic : IPresentationLogic
         var command = WorldCommandFactory.GetEditCommand(worldEntity, name, shortname, authors, language, description,
             goals, evaluationLink,
             world => CMapper.Map(world, learningWorldVm));
+        //quit early if there are no changes
+        if (!command.AnyChanges()) return;
         BusinessLogic.ExecuteCommand(command);
     }
 
@@ -247,6 +249,7 @@ public class PresentationLogic : IPresentationLogic
         var command = SpaceCommandFactory.GetEditCommand(spaceEntity, name, description, goals, requiredPoints, theme,
             topicEntity,
             space => CMapper.Map(space, learningSpaceVm));
+        if (!command.AnyChanges()) return;
         BusinessLogic.ExecuteCommand(command);
     }
 
@@ -512,6 +515,7 @@ public class PresentationLogic : IPresentationLogic
         var command = ElementCommandFactory.GetEditCommand(elementEntity, parentSpaceEntity, name, description,
             goals, difficulty, elementModel, workload, points, contentEntity,
             element => CMapper.Map(element, learningElementVm));
+        if (!command.AnyChanges()) return;
         BusinessLogic.ExecuteCommand(command);
     }
 

--- a/Presentation/PresentationLogic/API/PresentationLogic.cs
+++ b/Presentation/PresentationLogic/API/PresentationLogic.cs
@@ -165,7 +165,11 @@ public class PresentationLogic : IPresentationLogic
             goals, evaluationLink,
             world => CMapper.Map(world, learningWorldVm));
         //quit early if there are no changes
-        if (!command.AnyChanges()) return;
+        if (!command.AnyChanges())
+        {
+            Logger.LogInformation("No changes in edit learning world command, quitting before executing command");
+            return;
+        }
         BusinessLogic.ExecuteCommand(command);
     }
 
@@ -249,7 +253,11 @@ public class PresentationLogic : IPresentationLogic
         var command = SpaceCommandFactory.GetEditCommand(spaceEntity, name, description, goals, requiredPoints, theme,
             topicEntity,
             space => CMapper.Map(space, learningSpaceVm));
-        if (!command.AnyChanges()) return;
+        if (!command.AnyChanges())
+        {
+            Logger.LogInformation("No changes in edit learning space command, quitting before executing command");
+            return;
+        }
         BusinessLogic.ExecuteCommand(command);
     }
 
@@ -515,7 +523,11 @@ public class PresentationLogic : IPresentationLogic
         var command = ElementCommandFactory.GetEditCommand(elementEntity, parentSpaceEntity, name, description,
             goals, difficulty, elementModel, workload, points, contentEntity,
             element => CMapper.Map(element, learningElementVm));
-        if (!command.AnyChanges()) return;
+        if (!command.AnyChanges())
+        {
+            Logger.LogInformation("No changes in edit learning element command, quitting before executing command");
+            return;
+        }
         BusinessLogic.ExecuteCommand(command);
     }
 

--- a/PresentationTest/PresentationLogic/API/PresentationLogicUt.cs
+++ b/PresentationTest/PresentationLogic/API/PresentationLogicUt.cs
@@ -260,6 +260,7 @@ public class PresentationLogicUt
     {
         var mockBusinessLogic = Substitute.For<IBusinessLogic>();
         var mockCommand = Substitute.For<IEditLearningWorld>();
+        mockCommand.AnyChanges().Returns(true);
         var mockWorldCommandFactory = Substitute.For<IWorldCommandFactory>();
         var worldVm = ViewModelProvider.GetLearningWorld();
         var mockMapper = Substitute.For<IMapper>();
@@ -375,6 +376,7 @@ public class PresentationLogicUt
         var mockBusinessLogic = Substitute.For<IBusinessLogic>();
         var mockSpaceCommandFactory = Substitute.For<ISpaceCommandFactory>();
         var mockCommand = Substitute.For<IEditLearningSpace>();
+        mockCommand.AnyChanges().Returns(true);
         var learningSpaceVm = ViewModelProvider.GetLearningSpace();
         var mockMapper = Substitute.For<IMapper>();
         var learningSpaceEntity = EntityProvider.GetLearningSpace();
@@ -587,6 +589,7 @@ public class PresentationLogicUt
         var mockBusinessLogic = Substitute.For<IBusinessLogic>();
         var mockElementCommandFactory = Substitute.For<IElementCommandFactory>();
         var mockCommand = Substitute.For<IEditLearningElement>();
+        mockCommand.AnyChanges().Returns(true);
         var learningSpaceVm = ViewModelProvider.GetLearningSpace();
         var learningElementVm = ViewModelProvider.GetLearningElement(parent: learningSpaceVm);
         var learningContentVm = ViewModelProvider.GetFileContent();


### PR DESCRIPTION
Fixes #384
Bei Änderung eines Felds in einem Edit Dialog wird nun nach Ablauf des Debounce Intervalls (momentan überall 300ms) die Validierung ausgeführt. Nach erfolgreicher Validierung wird dann in BaseForm ein Callback aufgerufen, welcher in den Edit Dialogen ein Edit des momentan editierten Objekts auslöst.